### PR TITLE
Update hash algorithm to sha256

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
  * Module dependencies.
  */
 
-var md5 = require('md5');
+var sha256 = require('js-sha256');
 var jsonp = require('jsonp');
 var querystring = require('querystring');
 
@@ -19,7 +19,7 @@ exports.url = function (email, config) {
   config = config || {};
   var qs = querystring.stringify(config);
   var qs = qs === '' ? '' : '?' + qs;
-  var url = 'https://secure.gravatar.com/avatar/' + md5(email.trim().toLowerCase()) + qs;
+  var url = 'https://secure.gravatar.com/avatar/' + sha256(email.trim().toLowerCase()) + qs;
   return url;
 };
 
@@ -32,7 +32,7 @@ exports.url = function (email, config) {
  */
 
 exports.profile = function (email, fn) {
-  var url = 'https://secure.gravatar.com/' + md5(email.trim().toLowerCase());
+  var url = 'https://secure.gravatar.com/' + sha256(email.trim().toLowerCase());
   jsonp(url + '.json', function (err, obj) {
     if (err) return fn(err);
     if (obj && obj.entry) {

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "description": "Simple browser implementation of the Gravatar API",
   "version": "1.1.1",
   "dependencies": {
-    "md5-component": "0.0.1",
+    "component-querystring": "2.0.1",
     "jsonp": "0.1.0",
-    "component-querystring": "1.3.2"
+    "md5-component": "0.0.1"
   },
   "browser": {
     "md5": "md5-component",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "jsonp": "0.1.0"
   },
   "browser": {
-    "md5": "md5-component",
     "querystring": "component-querystring"
   },
   "component": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "1.1.1",
   "dependencies": {
     "component-querystring": "2.0.1",
+    "js-sha256": "0.9.0",
     "jsonp": "0.1.0",
     "md5-component": "0.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "dependencies": {
     "component-querystring": "2.0.1",
     "js-sha256": "0.9.0",
-    "jsonp": "0.1.0",
-    "md5-component": "0.0.1"
+    "jsonp": "0.1.0"
   },
   "browser": {
     "md5": "md5-component",


### PR DESCRIPTION
This PR updates the hashing algorithm to sha256 which is now supported by Gravatar.com

This PR is also [duplicated in the original repo](https://github.com/webmodules/gravatar/pull/12) with the hopes it gets integrated there as well, and updated in NPM. Otherwise, we can use this repo for imports for internal products (like Cloudup)

**Testing**
1. pull pr
2. run the following command to test the exported functions using your email address, and verify that the correct image is displayed in the browser
   - prints gravatar url `node -e "var gravatar = require('./index.js'); console.log(gravatar.url('someemail@example.com'))"`
   - prints a valid gravatar url with image size at 20px `node -e "var gravatar = require('./index.js'); console.log(gravatar.url('someemail@example.com', {s: 20}))"`
